### PR TITLE
2.0.2: Prevent bitcore versionGuard errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bookmoons/bitcore-message-cash",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Bitcore based message signing for Bitcoin Cash",
   "main": "index.js",
   "scripts": {
@@ -18,7 +18,7 @@
     "signing"
   ],
   "repository": "github:bookmoons/bitcore-message-cash",
-  "dependencies": {
+  "peerDependencies": {
     "bitcore-lib-cash": "^0.18.1"
   },
   "devDependencies": {


### PR DESCRIPTION
If you try to include this package as a dependency for another library, you will get bitcore errors

Any time bitcore is installed as a library where the library is intended to be used in other projects, the library should include bitcore as a peerDependency, unless it uses a specific thing in only that version of bitcore.

Basically, this PR helps make other libraries able to depend on your library
